### PR TITLE
Analytical gradient by parameter shift rule

### DIFF
--- a/qiskit/algorithms/optimizers/optimizer.py
+++ b/qiskit/algorithms/optimizers/optimizer.py
@@ -150,15 +150,15 @@ class Optimizer(ABC):
                 todo_results.append(f(todo))
         else:
             i = 0
-            chunks = []
             # split all points to chunks, where each chunk has batch_size points
             while i < len(todos):
-                chunks.append(todos[i : i + max_evals_grouped])
-                i += max_evals_grouped
-            for chunk in chunks:  # eval the chunks in order
-                parallel_parameters = np.concatenate(chunk)
                 # eval the points in a chunk (order preserved)
-                todo_results.extend(f(parallel_parameters))
+                results = f(np.concatenate(todos[i : i + max_evals_grouped]))
+                if isinstance(results, float):
+                    todo_results.append(results)
+                else:
+                    todo_results.extend(results)
+                i += max_evals_grouped
 
         grad = []
         div = 2 * np.sin(epsilon)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

analytical gradient by parameter shift rule

usage:
```python
opt = ChildOfSciPyOptimizer(...)
opt.optimize(objective_function=objective_function, ... other parameters ...,
    gradient_function=opt.wrap_function(opt.gradient_param_shift, (objective_function, 0, max_evals_grouped))
```
where `max_evals_grouped` can be an arbitrary natural number.

### Details and comments


